### PR TITLE
Update to lavalink.py v5

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -97,9 +97,11 @@ class MusicBot(commands.Bot):
         self.logger.debug("Bot Ready")
 
         self.session = aiohttp.ClientSession(loop=self.loop)
-        await self.change_presence(activity=discord.Game(type=0,
-                                                         name=conf["bot"]["playing status"]),
-                                   status=discord.Status.online)
+
+        if presence := conf["bot"]["playing status"]:
+            await self.change_presence(activity=discord.Game(type=0,
+                                                             name=presence),
+                                       status=discord.Status.online)
 
     def run(self):
         try:

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ clean:
 
 # Run ruff
 lint: venv
-    {{python}} -m ruff . --fix
+    {{python}} -m ruff check . --fix
 
 # Run tests
 test: venv

--- a/musicbot/cogs/music/__init__.py
+++ b/musicbot/cogs/music/__init__.py
@@ -7,6 +7,7 @@ import discord
 import lavalink
 from discord import VoiceChannel
 from discord.ext import commands, tasks
+from lavalink import AudioTrack
 from lavalink.events import (
     NodeChangedEvent,
     NodeConnectedEvent,
@@ -17,7 +18,6 @@ from lavalink.events import (
     TrackStartEvent,
     TrackStuckEvent,
 )
-from lavalink.models import AudioTrack
 
 from bs4 import BeautifulSoup
 

--- a/musicbot/utils/localisation/localizer/localizer.py
+++ b/musicbot/utils/localisation/localizer/localizer.py
@@ -78,7 +78,7 @@ class Localizer:
     def _parse_localization_dictionary(d, lookup, prefix=None):
         n_dict = {}
         for k, v in d.items():
-            if type(v) is str:
+            if isinstance(v, str):
                 n_dict[k] = Localizer._parse_localization_string(v, lookup, prefix)
             else:
                 n_dict[k] = v
@@ -137,11 +137,11 @@ class Localizer:
         cursorQueue = [nd]
         while cursorQueue:
             cursor = cursorQueue.pop()
-            for k, v in (cursor.items() if type(cursor) == dict else enumerate(cursor)):
-                if type(v) == str:
+            for k, v in (cursor.items() if isinstance(cursor, dict) else enumerate(cursor)):
+                if isinstance(v, str):
                     # insert translations based on lang
                     cursor[k] = self.format_str(v, lang, prefix, **kvpairs)
-                elif type(v) == dict or type(v) == list:
+                elif isinstance(v, dict) or isinstance(v, list):
                     cursorQueue.append(v)
 
         return nd

--- a/musicbot/utils/mixplayer/mixqueue.py
+++ b/musicbot/utils/mixplayer/mixqueue.py
@@ -4,7 +4,7 @@ from itertools import chain, cycle, islice
 from random import shuffle
 from typing import Generic, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
-from lavalink.models import AudioTrack
+from lavalink import AudioTrack
 
 # Would like to ensure the T has a "requester" attribute, but don't know if that is possible
 T = TypeVar('T', bound=AudioTrack)

--- a/musicbot/utils/mixplayer/player.py
+++ b/musicbot/utils/mixplayer/player.py
@@ -123,7 +123,7 @@ class MixPlayer(DefaultPlayer):
                 await self.bassboost(False)
                 await self.nightcoreify(False)
                 await self.stop()
-                await self.node._dispatch_event(QueueEndEvent(self))
+                await self.client._dispatch_event(QueueEndEvent(self))
                 return
             else:
                 # At this point track will not be None, as the queue is not empty
@@ -133,9 +133,9 @@ class MixPlayer(DefaultPlayer):
         if track is None or track.track is None:
             # Ignore, if the queue was empty we would have dispatched the event already
             return
-        await self.node._send(op='play', guildId=str(self.guild_id),
-                              track=track.track, startTime=start_time)
-        await self.node._dispatch_event(TrackStartEvent(self, track))
+        await self.play_track(track, start_time)
+
+        await self.client._dispatch_event(TrackStartEvent(self, track))
         self.logger.info(f"Playing track: {track.title}")
 
     async def skip(self, pos: int = 0):
@@ -149,7 +149,8 @@ class MixPlayer(DefaultPlayer):
 
     async def stop(self):
         """Stops the player."""
-        await self.node._send(op='stop', guildId=str(self.guild_id))
+        # await self.node._send(op='stop', guildId=str(self.guild_id))
+        await super().stop()
         self.current = None
         self.queue.enable_looping(False)
         self.logger.info("Music player stopped, clearing current track and stopping looping")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ pythonpath = ["."]
 
 [tool.ruff]
 # Allow lines to be as long as 120 characters.
-select = ["F", "E", "B", "W", "I001"]
+lint.select = ["F", "E", "B", "W", "I001"]
 line-length = 120
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 section-order = ["future", "standard-library", "discord", "third-party", "first-party", "local-folder"]
-[tool.ruff.isort.sections]
+[tool.ruff.lint.isort.sections]
 "discord" = ["discord", "lavalink"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ asyncio
 pyyaml
 BeautifulSoup4
 pytest
-ruff==0.0.274
+ruff
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py == 2.3.*
-lavalink == 4.0.*
+lavalink == 5.3.*
 asyncio
 pyyaml
 BeautifulSoup4


### PR DESCRIPTION
Adds support for lavalink v4 API.
Also allow empty status.

In order for this to work correctly this currently requires the most up to date version of lavalink, 
which does not yet have a release. This is because the latest release contains a fix a recent youtube change.